### PR TITLE
Веб хуки. Разделение для TG и Max

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,8 +192,10 @@ export MAX_TOKEN=your_token
 | `DATABASE_URL` | DSN для PostgreSQL (если задана — SQLite игнорируется) | — |
 | `TG_BOT_URL` | Ссылка на TG-бота (показывается в `/help`) | `https://t.me/MaxTelegramBridgeBot` |
 | `MAX_BOT_URL` | Ссылка на MAX-бота (показывается в `/help`) | `https://max.ru/id710708943262_bot` |
-| `WEBHOOK_URL` | Базовый URL для webhook, например `https://bridge.example.com` (если не задан — long polling). Эндпоинты: `/tg-webhook`, `/max-webhook` | — |
-| `WEBHOOK_PORT` | Порт для webhook сервера | `8443` |
+| `MAX_WEBHOOK_URL` | Базовый URL для webhook, например `https://bridge.example.com` (если не задан — long polling). Эндпоинт: `/max-webhook` | — |
+| `TG_WEBHOOK_URL` | Базовый URL для webhook, например `https://bridge.example.com` (если не задан — long polling). Эндпоинты: `/tg-webhook` | — |
+| `MAX_WEBHOOK_PORT` | Порт для webhook сервера MAX. Если порт совпадает с Telegram, значит будет общий сервер | `8443` |
+| `TG_WEBHOOK_PORT` | Порт для webhook сервера Telegram . Если порт совпадает с Max, значит будет общий сервер | `8443` |
 | `LOG_LEVEL` | Уровень логирования: `debug`, `info`, `warn`, `error` | `info` |
 | `TG_API_URL` | URL локального [Telegram Bot API сервера](https://github.com/tdlib/telegram-bot-api), например `http://localhost:8081`. Снимает лимиты на размер файлов | — |
 | `ALLOWED_USERS` | Белый список Telegram user ID через запятую. Если не задан — доступ открыт для всех | — |

--- a/bridge.go
+++ b/bridge.go
@@ -18,8 +18,10 @@ type Config struct {
 	MaxToken     string  // токен MAX API (нужен для direct-send/upload)
 	TgBotURL     string  // ссылка на TG-бота для /help
 	MaxBotURL    string  // ссылка на MAX-бота для /help
-	WebhookURL   string  // базовый URL для webhook (если пусто — long polling)
-	WebhookPort  string  // порт для webhook сервера
+	MaxWebhookURL  string  // базовый URL для webhook MAX (если пусто — long polling)
+	MaxWebhookPort string  // порт HTTP-сервера для MAX webhook (по умолчанию 8443)
+	TgWebhookURL   string  // базовый URL для webhook TG (если пусто — long polling)
+	TgWebhookPort  string  // порт HTTP-сервера для TG webhook (по умолчанию 8444)
 	TgAPIURL         string  // custom TG Bot API URL (если пусто — api.telegram.org)
 	AllowedUsers     []int64 // whitelist TG user IDs (empty = allow all)
 	TgMaxFileSizeMB  int     // max file size TG->MAX in MB (0 = unlimited)
@@ -324,20 +326,32 @@ func (b *Bridge) Run(ctx context.Context) {
 		}
 	}()
 
-	if b.cfg.WebhookURL != "" {
+	startWebhookServer := func(port string, label string) {
 		go func() {
-			addr := ":" + b.cfg.WebhookPort
+			addr := ":" + port
 			srv := &http.Server{
 				Addr:         addr,
 				ReadTimeout:  10 * time.Second,
 				WriteTimeout: 10 * time.Second,
 				IdleTimeout:  60 * time.Second,
 			}
-			slog.Info("Webhook server starting", "addr", addr)
+			slog.Info("Webhook server starting", "label", label, "addr", addr)
 			if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-				slog.Error("Webhook server failed", "err", err)
+				slog.Error("Webhook server failed", "label", label, "err", err)
 			}
 		}()
+	}
+
+	if b.cfg.MaxWebhookURL != "" && b.cfg.TgWebhookURL != "" && b.cfg.MaxWebhookPort == b.cfg.TgWebhookPort {
+		// оба на одном порту — один сервер
+		startWebhookServer(b.cfg.MaxWebhookPort, "MAX+TG")
+	} else {
+		if b.cfg.MaxWebhookURL != "" {
+			startWebhookServer(b.cfg.MaxWebhookPort, "MAX")
+		}
+		if b.cfg.TgWebhookURL != "" {
+			startWebhookServer(b.cfg.TgWebhookPort, "TG")
+		}
 	}
 
 	var wg sync.WaitGroup

--- a/main.go
+++ b/main.go
@@ -57,8 +57,10 @@ func main() {
 		MaxToken:    mustEnv("MAX_TOKEN"),
 		TgBotURL:    envOr("TG_BOT_URL", "https://t.me/MaxTelegramBridgeBot"),
 		MaxBotURL:   envOr("MAX_BOT_URL", "https://max.ru/id710708943262_bot"),
-		WebhookURL:  os.Getenv("WEBHOOK_URL"),
-		WebhookPort: envOr("WEBHOOK_PORT", "8443"),
+		MaxWebhookURL:  os.Getenv("MAX_WEBHOOK_URL"),
+		MaxWebhookPort: envOr("MAX_WEBHOOK_PORT", "8443"),
+		TgWebhookURL:   os.Getenv("TG_WEBHOOK_URL"),
+		TgWebhookPort:  envOr("TG_WEBHOOK_PORT", "8444"),
 		TgAPIURL:    os.Getenv("TG_API_URL"),
 	}
 

--- a/max.go
+++ b/max.go
@@ -17,9 +17,9 @@ import (
 func (b *Bridge) listenMax(ctx context.Context) {
 	var updates <-chan maxschemes.UpdateInterface
 
-	if b.cfg.WebhookURL != "" {
+	if b.cfg.MaxWebhookURL != "" {
 		whPath := b.maxWebhookPath()
-		whURL := strings.TrimRight(b.cfg.WebhookURL, "/") + whPath
+		whURL := strings.TrimRight(b.cfg.MaxWebhookURL, "/") + whPath
 		ch := make(chan maxschemes.UpdateInterface, 100)
 		http.HandleFunc(whPath, b.maxApi.GetHandler(ch))
 		updateTypes := []string{

--- a/max.go
+++ b/max.go
@@ -1007,6 +1007,8 @@ func (b *Bridge) forwardMaxToTg(ctx context.Context, msgUpd *maxschemes.MessageC
 	// Forward (репост) из MAX: оригинал лежит в Link.Message, а body.Text часто пустой
 	// (если юзер не дописал свой комментарий). Подмешиваем содержимое Link.Message.Text,
 	// иначе в TG прилетит пустое "Name:" сообщение.
+	// Вложения оригинала тоже лежат в Link.Message.Attachments — body.Attachments при
+	// пересылке пустой, поэтому их нужно взять явно.
 	markups := body.Markups
 	if lk := msgUpd.Message.Link; lk != nil && lk.Type == maxschemes.FORWARD {
 		fwd := strings.TrimSpace(lk.Message.Text)
@@ -1021,6 +1023,10 @@ func (b *Bridge) forwardMaxToTg(ctx context.Context, msgUpd *maxschemes.MessageC
 				text = fwd
 				markups = lk.Message.Markups
 			}
+		}
+		// Вложения оригинала добавляем перед вложениями обёртки (обычно она пустая).
+		if len(lk.Message.Attachments) > 0 {
+			body.Attachments = append(lk.Message.Attachments, body.Attachments...)
 		}
 	}
 

--- a/telegram.go
+++ b/telegram.go
@@ -16,9 +16,9 @@ import (
 func (b *Bridge) listenTelegram(ctx context.Context) {
 	var updates <-chan TGUpdate
 
-	if b.cfg.WebhookURL != "" {
+	if b.cfg.TgWebhookURL != "" {
 		whPath := b.tgWebhookPath()
-		whURL := strings.TrimRight(b.cfg.WebhookURL, "/") + whPath
+		whURL := strings.TrimRight(b.cfg.TgWebhookURL, "/") + whPath
 		if err := b.tg.SetWebhook(ctx, whURL); err != nil {
 			slog.Error("TG set webhook failed", "err", err)
 			return


### PR DESCRIPTION
Разделены вебхуки для Телеги и Макса. Для каждого свой URL и порт. Это очень полезно, в связи с изменения в API макса с 11.05.2026, так как вводят ограничения на pooling. Таким образом, макс может работать через вебхук, а телега через pooling.