### PR TITLE
fix: sendTgMediaFromURL: pass parseMode, replyToID for stickers and etc.

### DIFF
--- a/upload.go
+++ b/upload.go
@@ -77,7 +77,7 @@ func (b *Bridge) sendTgMediaFromURL(ctx context.Context, tgChatID int64, mediaUR
 	default:
 		// sticker и прочее — как фото
 		return b.tg.SendPhoto(ctx, tgChatID, file, &SendOpts{
-			Caption: caption, ThreadID: threadID,
+			Caption: caption, ParseMode: parseMode, ReplyToID: replyToID, ThreadID: threadID,
 		})
 	}
 }


### PR DESCRIPTION
Currently, when sending a sticker from MAX to Telegram, the sender's name is displayed incorrectly:
<img width="405" height="443" alt="изображение" src="https://github.com/user-attachments/assets/29b0fb65-56ff-48d5-8ffd-c6f533ac6a05" />
This commit fixes it:
<img width="375" height="448" alt="изображение" src="https://github.com/user-attachments/assets/7992e4f4-a22e-44c8-bb10-1bad57e2fefb" />
