### PR TITLE
Fix TG album captions: drop double attribution, keep caption on later photo

### DIFF
--- a/format.go
+++ b/format.go
@@ -110,14 +110,23 @@ func formatTgCaption(msg *TGMessage, prefix, newline bool) string {
 	return formatTgCaptionWithName(msg, tgName(msg), prefix, newline)
 }
 
+// tgMessageBody — сырое содержимое сообщения: текст, подпись или представление
+// контакта. Без атрибуции автора: она накладывается вызывающей стороной ровно раз.
+func tgMessageBody(msg *TGMessage) string {
+	if msg == nil {
+		return ""
+	}
+	if msg.Text != "" {
+		return msg.Text
+	}
+	if msg.Caption != "" {
+		return msg.Caption
+	}
+	return tgContactText(msg)
+}
+
 func formatTgCaptionWithName(msg *TGMessage, name string, prefix, newline bool) string {
-	text := msg.Text
-	if text == "" {
-		text = msg.Caption
-	}
-	if text == "" {
-		text = tgContactText(msg)
-	}
+	text := tgMessageBody(msg)
 	if name == "" {
 		return text
 	}

--- a/mediagroup.go
+++ b/mediagroup.go
@@ -364,19 +364,31 @@ func (b *Bridge) formatTgMediaGroupCaption(ctx context.Context, items []mediaGro
 	if len(items) == 0 {
 		return "", false
 	}
+	if isCrosspost {
+		// Crossposts arrive as prepared HTML in item.caption and carry no author name.
+		for _, item := range items {
+			if item.caption != "" {
+				return item.caption, true
+			}
+		}
+		return "", false
+	}
+	// Bridge items reach the buffer with the author attribution already applied, so
+	// item.caption is non-empty even for album parts that carry no caption at all.
+	// Selecting by it therefore always picked the first part — losing a caption
+	// attached to a later photo — and adding the attribution here a second time
+	// rendered as "Name: Name:". The raw Telegram caption is the only sound source:
+	// entities are offsets into it, not into the attributed string.
 	captionMessage := items[0].msg
 	caption := ""
 	var entities []Entity
 	for _, item := range items {
-		if item.caption != "" {
-			caption = item.caption
+		if text := tgMessageBody(item.msg); text != "" {
+			caption = text
 			entities = item.entities
 			captionMessage = item.msg
 			break
 		}
-	}
-	if isCrosspost {
-		return caption, caption != ""
 	}
 	body := tgEntitiesToHTML(caption, entities)
 	if forwardLine := tgForwardLine(captionMessage); forwardLine != "" {

--- a/mediagroup_caption_test.go
+++ b/mediagroup_caption_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -66,18 +67,51 @@ func TestStaleMediaGroupTimerCannotDetachNewerCaption(t *testing.T) {
 	}
 }
 
+// Album items are buffered the way telegram.go builds them: item.caption already
+// carries the sender attribution, so even a part without a caption is non-empty.
+func bridgeAlbumItem(chat ChatInfo, sender *ChatInfo, tgCaption string) mediaGroupItem {
+	msg := &TGMessage{Chat: chat, SenderChat: sender, Caption: tgCaption}
+	return mediaGroupItem{msg: msg, caption: formatTgCaptionWithName(msg, sender.Title, false, false)}
+}
+
 func TestBridgeMediaGroupCaptionUsesBoldSenderName(t *testing.T) {
 	b := &Bridge{}
-	msg := &TGMessage{
-		Chat:       ChatInfo{ID: -1001, Type: "supergroup"},
-		SenderChat: &ChatInfo{ID: -2002, Type: "channel", Title: "Александр"},
-	}
+	chat := ChatInfo{ID: -1001, Type: "supergroup"}
+	sender := &ChatInfo{ID: -2002, Type: "channel", Title: "Александр"}
 	caption, formatted := b.formatTgMediaGroupCaption(context.Background(), []mediaGroupItem{
-		{msg: msg},
-		{msg: msg, caption: "В том числе можно фото пересылать."},
+		bridgeAlbumItem(chat, sender, ""),
+		bridgeAlbumItem(chat, sender, "В том числе можно фото пересылать."),
 	}, -3003, false)
 	if !formatted || caption != "<b>Александр</b>: В том числе можно фото пересылать." {
 		t.Fatalf("caption=%q formatted=%v", caption, formatted)
+	}
+}
+
+// Telegram attaches the album caption to an arbitrary part — usually the first one,
+// but clients are free to put it on a later photo.
+func TestBridgeMediaGroupCaptionSurvivesOnLaterPhoto(t *testing.T) {
+	b := &Bridge{}
+	chat := ChatInfo{ID: -1001, Type: "supergroup"}
+	sender := &ChatInfo{ID: -2002, Type: "channel", Title: "Александр"}
+	caption, formatted := b.formatTgMediaGroupCaption(context.Background(), []mediaGroupItem{
+		bridgeAlbumItem(chat, sender, ""),
+		bridgeAlbumItem(chat, sender, "подпись на втором фото"),
+	}, -3003, false)
+	if !formatted || caption != "<b>Александр</b>: подпись на втором фото" {
+		t.Fatalf("caption=%q formatted=%v", caption, formatted)
+	}
+}
+
+func TestBridgeMediaGroupCaptionDoesNotRepeatSenderName(t *testing.T) {
+	b := &Bridge{}
+	chat := ChatInfo{ID: -1001, Type: "supergroup"}
+	sender := &ChatInfo{ID: -2002, Type: "channel", Title: "Александр"}
+	caption, _ := b.formatTgMediaGroupCaption(context.Background(), []mediaGroupItem{
+		bridgeAlbumItem(chat, sender, ""),
+		bridgeAlbumItem(chat, sender, ""),
+	}, -3003, false)
+	if strings.Count(caption, sender.Title) > 1 {
+		t.Fatalf("sender name repeated in caption=%q", caption)
 	}
 }
 


### PR DESCRIPTION
## Проблема

Альбом (media group), пересланный из Telegram в MAX, приходит с текстом вида `Имя: Имя:` — имя автора продублировано, а подпись альбома теряется целиком.

Боевой пример (2 фото + подпись, домовой чат): в MAX оседает текст `Михаил [КРСК]: Михаил [КРСК]:`, подписи нет. Одиночное фото при этом форматируется правильно: `Михаил [КРСК]: подпись`.

## Причина

Элементы альбома попадают в буфер уже с наложенной атрибуцией автора — `telegram.go` вызывает `formatTgCaptionWithName` до `bufferMediaGroup`. Поэтому `item.caption` непуст **даже у части без подписи**: там лежит голое `«Имя: »`.

`formatTgMediaGroupCaption` выбирала подпись именно по этому полю, отсюда два следствия:

1. Подпись, прикреплённая Telegram-клиентом не к первому фото, игнорировалась — первая часть всегда «выигрывала» отбор.
2. Атрибуция накладывалась второй раз поверх уже атрибутированной строки → `Имя: Имя:`. Вдобавок `entities` — это смещения в **сырой** подписи, а применялись они к строке с префиксом.

## Исправление

Брать подпись из исходного сообщения Telegram (`msg.Caption` / `msg.Text`), а атрибуцию накладывать ровно один раз — уже в `formatTgMediaGroupCaption`. Для кросспостов поведение не меняется: там `item.caption` — готовый HTML без атрибуции автора, он и используется.

Заодно вынесен хелпер `tgMessageBody` (текст / подпись / контакт), чтобы источник «сырого» содержимого был один.

## Про тесты

Существующий `TestBridgeMediaGroupCaptionUsesBoldSenderName` передавал в `item.caption` сырую подпись — форму, которой в проде не бывает (там всегда уже атрибутированная строка). Поэтому баг и проходил сквозь зелёный прогон. Фикстура приведена к боевой форме: элементы собираются так же, как их строит `telegram.go`.

Добавлены два теста: подпись на втором фото альбома и отсутствие повтора имени. Оба проверены против непропатченного кода — падают, воспроизводя ровно боевой симптом:

```
--- FAIL: TestBridgeMediaGroupCaptionSurvivesOnLaterPhoto
    caption="<b>Александр</b>: Александр: "
--- FAIL: TestBridgeMediaGroupCaptionDoesNotRepeatSenderName
    sender name repeated in caption="<b>Александр</b>: Александр: "
```

С патчем `go test ./...` и `go vet ./...` проходят полностью. Изменение проверено на живой связке TG-супергруппа ↔ MAX-группа.
